### PR TITLE
Add missing cstdint include in JsonEncoder.h

### DIFF
--- a/runtime/src/zserio/JsonEncoder.h
+++ b/runtime/src/zserio/JsonEncoder.h
@@ -1,6 +1,7 @@
 #ifndef ZSERIO_JSON_ENCODER_H_INC
 #define ZSERIO_JSON_ENCODER_H_INC
 
+#include <cstdint>
 #include <string_view>
 #include <type_traits>
 


### PR DESCRIPTION
On GCC 15.2.X `JsonEncoder.h` is missing the `cstdint` include for `[u]int64_t`.