### PR TITLE
Templated Struct View is Missing the zserioData() Implementation

### DIFF
--- a/extension/freemarker/StructureTemplate.h.ftl
+++ b/extension/freemarker/StructureTemplate.h.ftl
@@ -264,7 +264,10 @@ public:
     </#items>
 </#list>
 
-    const ${fullName}& zserioData() const;
+    const ${fullName}& zserioData() const
+    {
+        return *m_data;
+    }
 
 protected:
     View(const ${fullName}& data, const View&<#if parameterList?has_content> other</#if>) noexcept :


### PR DESCRIPTION
For templated structs, no *.cpp file is generated, but the header template provides no `zserioData()` implementation which leads to linker errors.