### PR TITLE
Fix this-escape Warning

### DIFF
--- a/extension/src/zserio/extension/cpp17/CompoundTypeTemplateData.java
+++ b/extension/src/zserio/extension/cpp17/CompoundTypeTemplateData.java
@@ -17,6 +17,7 @@ import zserio.extension.common.ZserioExtensionException;
  */
 public class CompoundTypeTemplateData extends UserTypeTemplateData
 {
+    @SuppressWarnings("this-escape")
     public CompoundTypeTemplateData(TemplateDataContext context, CompoundType compoundType)
             throws ZserioExtensionException
     {

--- a/extension/src/zserio/extension/cpp17/types/NativeAllocType.java
+++ b/extension/src/zserio/extension/cpp17/types/NativeAllocType.java
@@ -1,5 +1,8 @@
 package zserio.extension.cpp17.types;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import zserio.ast.PackageName;
 import zserio.extension.cpp17.TypesContext;
 
@@ -64,12 +67,26 @@ public class NativeAllocType extends NativeType
     private NativeAllocType(TypesContext.NativeTypeDefinition nativeTypeDefinition,
             TypesContext.AllocatorDefinition allocatorDefinition, PackageName packageName, String name)
     {
-        super(packageName, name);
+        super(packageName, name, makeSystemIncludes(nativeTypeDefinition, allocatorDefinition), null);
 
         needsAllocatorArgument = nativeTypeDefinition.needsAllocatorArgument();
-        if (needsAllocatorArgument)
-            addSystemIncludeFile(allocatorDefinition.getAllocatorSystemInclude());
-        addSystemIncludeFile(nativeTypeDefinition.getSystemInclude());
+    }
+
+    private static Collection<String> makeSystemIncludes(TypesContext.NativeTypeDefinition nativeTypeDefinition,
+            TypesContext.AllocatorDefinition allocatorDefinition)
+    {
+        Collection<String> systemIncludes = new ArrayList<String>();
+
+        final boolean needsAllocatorArgument = nativeTypeDefinition.needsAllocatorArgument();
+        final String allocatorSystemInclude = allocatorDefinition.getAllocatorSystemInclude();
+        if (needsAllocatorArgument && allocatorSystemInclude != null)
+            systemIncludes.add(allocatorDefinition.getAllocatorSystemInclude());
+
+        final String systemInclude = nativeTypeDefinition.getSystemInclude();
+        if (systemInclude != null)
+            systemIncludes.add(systemInclude);
+
+        return systemIncludes;
     }
 
     private final boolean needsAllocatorArgument;

--- a/extension/src/zserio/extension/cpp17/types/NativeArrayTraits.java
+++ b/extension/src/zserio/extension/cpp17/types/NativeArrayTraits.java
@@ -1,5 +1,7 @@
 package zserio.extension.cpp17.types;
 
+import java.util.Collections;
+
 /**
  * Native C++ array traits mapping.
  */
@@ -7,7 +9,6 @@ public class NativeArrayTraits extends NativeZserioType
 {
     public NativeArrayTraits(String name)
     {
-        super(name);
-        addSystemIncludeFile("zserio/ArrayTraits.h");
+        super(name, Collections.singleton("zserio/ArrayTraits.h"), null);
     }
 };

--- a/extension/src/zserio/extension/cpp17/types/NativeNumericWrapperType.java
+++ b/extension/src/zserio/extension/cpp17/types/NativeNumericWrapperType.java
@@ -1,5 +1,7 @@
 package zserio.extension.cpp17.types;
 
+import java.util.Collections;
+
 /**
  * Native C++ runtime type mapping.
  */
@@ -7,9 +9,8 @@ public class NativeNumericWrapperType extends NativeZserioType
 {
     public NativeNumericWrapperType(String name, String nativeTypeName)
     {
-        super(name);
+        super(name, Collections.singleton("zserio/Types.h"), null);
         this.nativeTypeName = nativeTypeName;
-        addSystemIncludeFile("zserio/Types.h");
     }
 
     String getNativeTypeName()

--- a/extension/src/zserio/extension/cpp17/types/NativeStdType.java
+++ b/extension/src/zserio/extension/cpp17/types/NativeStdType.java
@@ -1,5 +1,7 @@
 package zserio.extension.cpp17.types;
 
+import java.util.Collections;
+
 import zserio.ast.PackageName;
 
 /**
@@ -19,9 +21,8 @@ public class NativeStdType extends NativeType
 
     public NativeStdType(PackageName packageName, String name, String systemIncludeFile)
     {
-        super(packageName, name);
-
-        addSystemIncludeFile(systemIncludeFile);
+        super(packageName, name, systemIncludeFile != null ? Collections.singleton(systemIncludeFile) : null,
+                null);
     }
 
     private static final PackageName STD_PACKAGE_NAME = new PackageName.Builder().addId("std").get();

--- a/extension/src/zserio/extension/cpp17/types/NativeType.java
+++ b/extension/src/zserio/extension/cpp17/types/NativeType.java
@@ -1,5 +1,6 @@
 package zserio.extension.cpp17.types;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -14,10 +15,20 @@ public class NativeType implements CppNativeType
 {
     public NativeType(PackageName packageName, String name)
     {
+        this(packageName, name, null, null);
+    }
+
+    protected NativeType(PackageName packageName, String name, Collection<String> systemIncludes,
+            Collection<String> userIncludes)
+    {
         this.packageName = packageName;
         this.name = name;
         this.systemIncludeFiles = new TreeSet<String>();
         this.userIncludeFiles = new TreeSet<String>();
+        if (systemIncludes != null)
+            this.systemIncludeFiles.addAll(systemIncludes);
+        if (userIncludes != null)
+            this.userIncludeFiles.addAll(userIncludes);
     }
 
     @Override
@@ -50,19 +61,19 @@ public class NativeType implements CppNativeType
         return Collections.unmodifiableSortedSet(userIncludeFiles);
     }
 
-    protected void addSystemIncludeFile(String include)
+    protected final void addSystemIncludeFile(String include)
     {
         if (include != null)
             systemIncludeFiles.add(include);
     }
 
-    protected void addUserIncludeFile(String include)
+    protected final void addUserIncludeFile(String include)
     {
         if (include != null)
             userIncludeFiles.add(include);
     }
 
-    protected void addIncludeFiles(CppNativeType other)
+    protected final void addIncludeFiles(CppNativeType other)
     {
         for (String systemInclude : other.getSystemIncludeFiles())
         {

--- a/extension/src/zserio/extension/cpp17/types/NativeUserType.java
+++ b/extension/src/zserio/extension/cpp17/types/NativeUserType.java
@@ -1,5 +1,7 @@
 package zserio.extension.cpp17.types;
 
+import java.util.Collections;
+
 import zserio.ast.PackageName;
 
 /**
@@ -9,7 +11,6 @@ public class NativeUserType extends NativeType
 {
     public NativeUserType(PackageName packageName, String name, String includeFileName)
     {
-        super(packageName, name);
-        addUserIncludeFile(includeFileName);
+        super(packageName, name, null, includeFileName != null ? Collections.singleton(includeFileName) : null);
     }
 }

--- a/extension/src/zserio/extension/cpp17/types/NativeZserioType.java
+++ b/extension/src/zserio/extension/cpp17/types/NativeZserioType.java
@@ -1,5 +1,7 @@
 package zserio.extension.cpp17.types;
 
+import java.util.Collection;
+
 import zserio.ast.PackageName;
 
 /**
@@ -10,6 +12,11 @@ public class NativeZserioType extends NativeType
     public NativeZserioType(String name)
     {
         super(ZSERIO_PACKAGE_NAME, name);
+    }
+
+    protected NativeZserioType(String name, Collection<String> systemIncludes, Collection<String> userIncludes)
+    {
+        super(ZSERIO_PACKAGE_NAME, name, systemIncludes, userIncludes);
     }
 
     private static final PackageName ZSERIO_PACKAGE_NAME = new PackageName.Builder().addId("zserio").get();


### PR DESCRIPTION
Do not use `add*IncludeFiles` in child-class constructors to prevent `this-escape` warnings, which lead to compilation errors (`-Werror`).

See: https://bugs.openjdk.org/browse/JDK-8299995